### PR TITLE
Add error checking for cache

### DIFF
--- a/src/backfill.js
+++ b/src/backfill.js
@@ -15,25 +15,22 @@ var days = +argv.days;
 const store = path.join(__dirname, "./../data");
 
 const backfill = async function() {
-  return new Promise(async (resolve, reject) => {
-    const envelope = turf.bboxPolygon(config.boundary).geometry;
+  const envelope = turf.bboxPolygon(config.boundary).geometry;
 
-    // get graph
-    const graphOpts = {
-      source: "osm/planet-181224",
-      tileHierarchy: 6
-    };
-    var graph = new shst.Graph(envelope, graphOpts);
-    await graph.buildGraph();
-    var pointMatcher = new shst.PointMatcher(envelope, graphOpts);
+  // get graph
+  const graphOpts = {
+    source: "osm/planet-181224",
+    tileHierarchy: 6
+  };
+  var graph = new shst.Graph(envelope, graphOpts);
+  await graph.buildGraph();
+  var pointMatcher = new shst.PointMatcher(envelope, graphOpts);
 
-    while (days--) {
-      const current = day.clone().subtract(days, "day");
-      console.log("building: ", current.format("YYYY-MM-DD"));
-      await summarize(current.format("YYYY-MM-DD"), shst, graph, pointMatcher);
-    }
-    resolve();
-  });
+  while (days--) {
+    const current = day.clone().subtract(days, "day");
+    console.log("building: ", current.format("YYYY-MM-DD"));
+    await summarize(current.format("YYYY-MM-DD"), shst, graph, pointMatcher);
+  }
 };
 
 const clearDir = async function(dir) {
@@ -47,4 +44,6 @@ const clearDir = async function(dir) {
 backfill().then(() => {
   if (debug) rimraf.sync(path.join(__dirname, "./../cache"));
   console.log("\ncompleted backfill");
+}).catch(err => {
+  console.error(err.message);
 });

--- a/src/providers/bird.js
+++ b/src/providers/bird.js
@@ -14,14 +14,20 @@ function trips(stream, start, stop) {
     }
   };
 
-  scan(opts, () => {
-    stream.end();
+  scan(opts, (err) => {
+    if (err)
+      stream.destroy(err);
+    else
+      stream.end();
   });
 
   // recursive scan across
   function scan(opts, cb) {
     request.get(opts, (err, res, body) => {
-      if (err) throw err;
+      if (err) {
+        cb(err);
+        return;
+      }
 
       var data = JSON.parse(body);
 
@@ -51,14 +57,20 @@ function changes(stream, start, stop) {
     }
   };
 
-  scan(opts, () => {
-    stream.end();
+  scan(opts, (err) => {
+    if (err)
+      stream.destroy(err);
+    else
+      stream.end();
   });
 
   // recursive scan across
   function scan(opts, cb) {
     request.get(opts, (err, res, body) => {
-      if (err) throw err;
+      if (err) {
+        cb(err);
+        return;
+      }
 
       var data = JSON.parse(body);
       // write any returned changes to stream

--- a/src/providers/jump.js
+++ b/src/providers/jump.js
@@ -13,14 +13,20 @@ function trips(stream, start, stop) {
     }
   };
 
-  scan(opts, () => {
-    stream.end();
+  scan(opts, (err) => {
+    if (err)
+      stream.destroy(err);
+    else
+      stream.end();
   });
 
   // recursive scan across
   function scan(opts, cb) {
     request.get(opts, (err, res, body) => {
-      if (err) throw err;
+      if (err) {
+        cb(err);
+        return;
+      }
 
       var data = JSON.parse(body);
 
@@ -51,14 +57,20 @@ function changes(stream, start, stop) {
     }
   };
 
-  scan(opts, () => {
-    stream.end();
+  scan(opts, (err) => {
+    if (err)
+      stream.destroy(err);
+    else
+      stream.end();
   });
 
   // recursive scan across
   function scan(opts, cb) {
     request.get(opts, (err, res, body) => {
-      if (err) throw err;
+      if (err) {
+        cb(err);
+        return;
+      }
 
       var data = JSON.parse(body);
       // write any returned changes to stream

--- a/src/summarize.js
+++ b/src/summarize.js
@@ -17,180 +17,176 @@ var Z = 9;
 var privacyMinimum = config.privacyMinimum || 3;
 
 const summarize = async function(day, shst, graph, pointMatcher) {
-  return new Promise(async (resolve, reject) => {
-    var cachePath = path.join(__dirname + "./../cache", day);
-    if (!fs.existsSync(cachePath)) {
-      console.log("  caching...");
-      await cache(day);
-    }
+  var cachePath = path.join(__dirname + "./../cache", day);
+  if (!fs.existsSync(cachePath)) {
+    console.log("  caching...");
+    await cache(day);
+  }
 
-    console.log("  summarizing...");
-    for (let provider of providers) {
-      var cacheProviderPath = path.join(cachePath, provider);
+  console.log("  summarizing...");
+  for (let provider of providers) {
+    var cacheProviderPath = path.join(cachePath, provider);
 
-      console.log("    " + provider + "...");
+    console.log("    " + provider + "...");
 
-      var trips = fs
-        .readFileSync(path.join(cacheProviderPath, "trips.json"))
-        .toString()
-        .split("\n")
-        .filter(line => {
-          return line.length;
-        })
-        .map(JSON.parse);
-      var changes = fs
-        .readFileSync(path.join(cacheProviderPath, "changes.json"))
-        .toString()
-        .split("\n")
-        .filter(line => {
-          return line.length;
-        })
-        .map(JSON.parse);
+    var trips = fs
+      .readFileSync(path.join(cacheProviderPath, "trips.json"))
+      .toString()
+      .split("\n")
+      .filter(line => {
+        return line.length;
+      })
+      .map(JSON.parse);
+    var changes = fs
+      .readFileSync(path.join(cacheProviderPath, "changes.json"))
+      .toString()
+      .split("\n")
+      .filter(line => {
+        return line.length;
+      })
+      .map(JSON.parse);
 
-      var totalVehicles = new Set();
-      var totalActiveVehicles = new Set();
-      var stats = {
-        totalVehicles: 0,
-        totalActiveVehicles: 0,
-        totalTrips: 0,
-        totalDistance: 0,
-        totalDuration: 0,
-        geometry: {
-          bins: {},
-          streets: {},
-          pairs: {}
+    var totalVehicles = new Set();
+    var totalActiveVehicles = new Set();
+    var stats = {
+      totalVehicles: 0,
+      totalActiveVehicles: 0,
+      totalTrips: 0,
+      totalDistance: 0,
+      totalDuration: 0,
+      geometry: {
+        bins: {},
+        streets: {},
+        pairs: {}
+      },
+      tripVolumes: {
+        bins: {
+          day: {},
+          hour: {},
+          minute: {}
         },
-        tripVolumes: {
-          bins: {
-            day: {},
-            hour: {},
-            minute: {}
-          },
-          streets: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
-        },
-        pickups: {
-          bins: {
-            day: {},
-            hour: {},
-            minute: {}
-          },
-          streets: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
-        },
-        dropoffs: {
-          bins: {
-            day: {},
-            hour: {},
-            minute: {}
-          },
-          streets: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
-        },
-        flows: {
-          pairs: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
-        },
-        availability: {
-          bins: {
-            day: {},
-            hour: {},
-            minute: {}
-          },
-          streets: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
-        },
-        onstreet: {
-          bins: {
-            day: {},
-            hour: {},
-            minute: {}
-          },
-          streets: {
-            day: {},
-            hour: {},
-            minute: {}
-          }
+        streets: {
+          day: {},
+          hour: {},
+          minute: {}
         }
-      };
-
-      for (let trip of trips) {
-        totalVehicles.add(trip.vehicle_id);
-        totalActiveVehicles.add(trip.vehicle_id);
-
-        // convert to miles
-        trip.trip_distance = trip.trip_distance * 0.000621371;
-        // convert to minutes
-        trip.trip_duration = trip.trip_duration / 60;
-
-        // summary stats
-        stats.totalActiveVehicles = totalActiveVehicles.size;
-        stats.totalTrips++;
-        stats.totalDistance += trip.trip_distance;
-        stats.totalDuration += trip.trip_duration;
-        stats.averageVehicleDistance =
-          stats.totalDistance / stats.totalActiveVehicles;
-        stats.averageVehicleDuration =
-          stats.totalDuration / stats.totalActiveVehicles;
-        stats.averageTripDistance = stats.totalDistance / stats.totalTrips;
-        stats.averageTripDuration = stats.totalDuration / stats.totalTrips;
-        stats.averageTrips = stats.totalTrips / stats.totalActiveVehicles;
+      },
+      pickups: {
+        bins: {
+          day: {},
+          hour: {},
+          minute: {}
+        },
+        streets: {
+          day: {},
+          hour: {},
+          minute: {}
+        }
+      },
+      dropoffs: {
+        bins: {
+          day: {},
+          hour: {},
+          minute: {}
+        },
+        streets: {
+          day: {},
+          hour: {},
+          minute: {}
+        }
+      },
+      flows: {
+        pairs: {
+          day: {},
+          hour: {},
+          minute: {}
+        }
+      },
+      availability: {
+        bins: {
+          day: {},
+          hour: {},
+          minute: {}
+        },
+        streets: {
+          day: {},
+          hour: {},
+          minute: {}
+        }
+      },
+      onstreet: {
+        bins: {
+          day: {},
+          hour: {},
+          minute: {}
+        },
+        streets: {
+          day: {},
+          hour: {},
+          minute: {}
+        }
       }
+    };
 
-      // build state histories for each vehicle
-      var states = {};
-      changes.forEach(change => {
-        if (!states[change.vehicle_id]) {
-          totalVehicles.add(change.vehicle_id);
-          stats.totalVehicles = totalVehicles.size;
-          states[change.vehicle_id] = [];
-        }
-        states[change.vehicle_id].push(change);
-      });
-      // sort by time
-      Object.keys(states).forEach(id => {
-        states[id] = states[id].sort((a, b) => {
-          return a.event_time - b.event_time;
-        });
-      });
+    for (let trip of trips) {
+      totalVehicles.add(trip.vehicle_id);
+      totalActiveVehicles.add(trip.vehicle_id);
 
-      console.log("      trip volumes...");
-      await tripVolumes(stats, trips, graph);
-      console.log("      pickups...");
-      await pickups(stats, trips, pointMatcher);
-      console.log("      dropoffs...");
-      await dropoffs(stats, trips, pointMatcher);
-      console.log("      flows...");
-      flows(stats, trips);
-      console.log("      availability...");
-      await availability(stats, states, day, pointMatcher);
-      console.log("      onstreet...");
-      await onstreet(stats, states, day, pointMatcher);
+      // convert to miles
+      trip.trip_distance = trip.trip_distance * 0.000621371;
+      // convert to minutes
+      trip.trip_duration = trip.trip_duration / 60;
 
-      var summaryPath = path.join(__dirname + "./../data", day);
-      mkdirp.sync(summaryPath);
-      summaryFilePath = path.join(summaryPath, provider + ".json");
-
-      fs.writeFileSync(summaryFilePath, JSON.stringify(stats));
-
-      resolve();
+      // summary stats
+      stats.totalActiveVehicles = totalActiveVehicles.size;
+      stats.totalTrips++;
+      stats.totalDistance += trip.trip_distance;
+      stats.totalDuration += trip.trip_duration;
+      stats.averageVehicleDistance =
+        stats.totalDistance / stats.totalActiveVehicles;
+      stats.averageVehicleDuration =
+        stats.totalDuration / stats.totalActiveVehicles;
+      stats.averageTripDistance = stats.totalDistance / stats.totalTrips;
+      stats.averageTripDuration = stats.totalDuration / stats.totalTrips;
+      stats.averageTrips = stats.totalTrips / stats.totalActiveVehicles;
     }
-  });
+
+    // build state histories for each vehicle
+    var states = {};
+    changes.forEach(change => {
+      if (!states[change.vehicle_id]) {
+        totalVehicles.add(change.vehicle_id);
+        stats.totalVehicles = totalVehicles.size;
+        states[change.vehicle_id] = [];
+      }
+      states[change.vehicle_id].push(change);
+    });
+    // sort by time
+    Object.keys(states).forEach(id => {
+      states[id] = states[id].sort((a, b) => {
+        return a.event_time - b.event_time;
+      });
+    });
+
+    console.log("      trip volumes...");
+    await tripVolumes(stats, trips, graph);
+    console.log("      pickups...");
+    await pickups(stats, trips, pointMatcher);
+    console.log("      dropoffs...");
+    await dropoffs(stats, trips, pointMatcher);
+    console.log("      flows...");
+    flows(stats, trips);
+    console.log("      availability...");
+    await availability(stats, states, day, pointMatcher);
+    console.log("      onstreet...");
+    await onstreet(stats, states, day, pointMatcher);
+
+    var summaryPath = path.join(__dirname + "./../data", day);
+    mkdirp.sync(summaryPath);
+    summaryFilePath = path.join(summaryPath, provider + ".json");
+
+    fs.writeFileSync(summaryFilePath, JSON.stringify(stats));
+  }
 };
 
 function getTimeBins(timestamp) {


### PR DESCRIPTION
This PR does a few things that were required for error handling.

Currently, if an error occurs during the provider query, the `cache.js` queue will complete with an error (ignored) and the Promise will resolve as if the caching succeeded. However, the summarization process will fail later with an `ENOENT: no such file or directory` error for the provider's cache JSON files, since they will not exist. This makes it hard to debug provider-related issues.

This PR ensures that any error gets tagged with the provider name and is passed up to the entry point (`backfill.js`) where it will be printed to the console. Example: `cannot query lime changes: x is not defined`

In order to allow the errors to propagate up, I removed the explicit Promise from two async functions. These weren't really needed because an `async` function will generate an implicit Promise. Leaving them off makes the code a little cleaner, allows an error to propagate, and also fixes a potential bug in `summarize.js` where the `resolve` function was being called in a loop (the `await` will continue as soon as the first provider is complete).

As a side bonus, the provider queries can now report an error by calling `.destroy(new Error(...))` on the stream object.

Let me know if I should adjust this in any way, thanks!