### PR TITLE
Multiversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 ---
 
+## 4.4.0
+
+- implements an optional "version" setting that can be set per provider
+- setting to "0.3" will use the MDS 0.3 request headers and parameters when performing queries
+- leaving version blank will fall back to 0.2 request structure
+- varying MDS versions are normalized, allowing multiple providers to be combined across version implementations
+
 ## 4.3.0
 
 - add geo filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 ---
 
+## 4.3.0
+
+- add geo filter
+- add vehicle type filter
+- config fallbacks to prevent errors when missing values
+
 ## 4.1.0
 
 - document requirement for MDS >=0.3

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ A `config.json` file is required to run Mobility Metrics. Enable providers and s
   - list of providers to query
     - `type`
       - "local" for data off disk or "mds" for data off MDS provider API
+    - `version`
+      - sets the version of MDS to target; defaults to 0.2, but to use 0.3, set version to "0.3"
     - `trips`
       - URI of trip data
     - `status_changes`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobility-metrics",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobility-metrics",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "tools for aggregating mobility data",
   "bin": "./src/cli.js",
   "scripts": {

--- a/src/providers/mds.js
+++ b/src/providers/mds.js
@@ -15,18 +15,36 @@ async function trips(
   version
 ) {
   return new Promise(async (resolve, reject) => {
-    var opts = {
-      url:
-        provider.trips +
-        "?start_time=" +
-        start.toString() +
-        "&end_time=" +
-        stop.toString(),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: provider.token
-      }
-    };
+    var opts = {};
+
+    if (provider.version === "0.3") {
+      opts = {
+        url:
+          provider.trips +
+          "?min_end_time=" +
+          start.toString() +
+          "&max_end_time=" +
+          stop.toString(),
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/vnd.mds.provider+json;version=0.3",
+          Authorization: provider.token
+        }
+      };
+    } else {
+      opts = {
+        url:
+          provider.status_changes +
+          "?start_time=" +
+          start.toString() +
+          "&end_time=" +
+          stop.toString(),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: provider.token
+        }
+      };
+    }
 
     // recursive scan across
     async function scan(opts, done) {
@@ -75,18 +93,36 @@ async function changes(
   version
 ) {
   return new Promise(async (resolve, reject) => {
-    var opts = {
-      url:
-        provider.status_changes +
-        "?start_time=" +
-        start.toString() +
-        "&end_time=" +
-        stop.toString(),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: provider.token
-      }
-    };
+    var opts = {};
+
+    if (provider.version === "0.3") {
+      opts = {
+        url:
+          provider.status_changes +
+          "?start_time=" +
+          start.toString() +
+          "&end_time=" +
+          stop.toString(),
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/vnd.mds.provider+json;version=0.3",
+          Authorization: provider.token
+        }
+      };
+    } else {
+      opts = {
+        url:
+          provider.status_changes +
+          "?start_time=" +
+          start.toString() +
+          "&end_time=" +
+          stop.toString(),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: provider.token
+        }
+      };
+    }
 
     // recursive scan across
     async function scan(opts, done) {


### PR DESCRIPTION
This release implements an optional "version" setting that can be set per provider. Setting to "0.3" will use the MDS 0.3 request headers and parameters when performing queries. Leaving version blank will fall back to 0.2 request structure.