### PR TITLE
implement version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 ---
 
+## 4.5.0
+
+- add `-v,--version` flags to check version number
+
 ## 4.4.0
 
 - implements an optional "version" setting that can be set per provider

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ The CLI is responsible for downloading raw data, running aggregation and reports
 mobility-metrics --config ./example/example.json --public ./public --cache ./cache --day 2019-07-20;
 ```
 
+## Version
+
+To check the version of the CLI you are running, use the `-v` or `--version` flags.
+
 ## Docker
 
 Docker is supported, and is recommended when installation is challenging on bespoke systems that fail when installing dependencies, such as OSRM.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const path = require("path");
+const fs = require("fs");
 const moment = require("moment");
 const rimraf = require("rimraf");
 const shst = require("sharedstreets");
@@ -9,6 +10,14 @@ const summarize = require("./summarize");
 const cover = require("@mapbox/tile-cover");
 
 var argv = require("minimist")(process.argv.slice(2));
+
+if (argv.version || argv.v) {
+  const version = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../package.json"))
+  ).version;
+  console.log("v" + version);
+  process.exit(0);
+}
 
 if (argv.help || argv.h || Object.keys(argv).length === 1) {
   var help = "";


### PR DESCRIPTION
This PR implements the version flag, which can be used by adding one of the following optional flags:

- `-v`
- `--version`